### PR TITLE
Depend on System.Text.Json instead of Newtonsoft.Json at the top level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 .idea/
 *.sln.DotSettings.user
+.vs/

--- a/ApiSurface.DocumentationSample/ApiSurface.DocumentationSample.fsproj
+++ b/ApiSurface.DocumentationSample/ApiSurface.DocumentationSample.fsproj
@@ -6,4 +6,14 @@
   <ItemGroup>
     <Compile Include="KitchenSink.fs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ApiSurface\ApiSurface.fsproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!--
+    This is not necessary in user code, since FSharp.Core maintains backward compatibility.
+    But since this project builds ApiSurface from source, we fix the FSharp.Core version.
+    -->
+    <PackageReference Include="FSharp.Core" Version="4.3.4" />
+  </ItemGroup>
 </Project>

--- a/ApiSurface.DocumentationSample/ApiSurface.DocumentationSample.fsproj
+++ b/ApiSurface.DocumentationSample/ApiSurface.DocumentationSample.fsproj
@@ -6,14 +6,4 @@
   <ItemGroup>
     <Compile Include="KitchenSink.fs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\ApiSurface\ApiSurface.fsproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <!--
-    This is not necessary in user code, since FSharp.Core maintains backward compatibility.
-    But since this project builds ApiSurface from source, we fix the FSharp.Core version.
-    -->
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
-  </ItemGroup>
 </Project>

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.2" />
     <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />

--- a/ApiSurface/SurfaceBaseline.txt
+++ b/ApiSurface/SurfaceBaseline.txt
@@ -98,11 +98,11 @@ ApiSurface.SurfaceComparisonModule.AssertIdentical [static method]: ApiSurface.S
 ApiSurface.SurfaceComparisonModule.AssertNoneRemoved [static method]: bool -> ApiSurface.SurfaceComparison -> unit
 ApiSurface.SurfaceComparisonModule.RemovedSymbols [static method]: ApiSurface.SurfaceComparison -> string list
 ApiSurface.VersionFile inherit obj, implements ApiSurface.VersionFile System.IEquatable, System.Collections.IStructuralEquatable, ApiSurface.VersionFile System.IComparable, System.IComparable, System.Collections.IStructuralComparable
-ApiSurface.VersionFile..ctor [constructor]: (string, string list, string list)
-ApiSurface.VersionFile.get_PathFilters [method]: unit -> string list
+ApiSurface.VersionFile..ctor [constructor]: (string, string list, string list option)
+ApiSurface.VersionFile.get_PathFilters [method]: unit -> string list option
 ApiSurface.VersionFile.get_PublicReleaseRefSpec [method]: unit -> string list
 ApiSurface.VersionFile.get_Version [method]: unit -> string
-ApiSurface.VersionFile.PathFilters [property]: [read-only] string list
+ApiSurface.VersionFile.PathFilters [property]: [read-only] string list option
 ApiSurface.VersionFile.PublicReleaseRefSpec [property]: [read-only] string list
 ApiSurface.VersionFile.Version [property]: [read-only] string
 ApiSurface.VersionFileModule inherit obj

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPublishable>false</IsPublishable>
@@ -12,6 +12,7 @@
     <Compile Include="TestApiSurface.fs" />
     <Compile Include="TestMonotonicVersion.fs" />
     <Compile Include="TestType.fs" />
+    <Compile Include="TestVersionFile.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />

--- a/ApiSurface/Test/TestVersionFile.fs
+++ b/ApiSurface/Test/TestVersionFile.fs
@@ -1,0 +1,78 @@
+﻿namespace ApiSurface.Test
+
+open System.IO
+open ApiSurface
+open NUnit.Framework
+open FsUnitTyped
+
+[<TestFixture>]
+module TestVersionFile =
+
+    let parse (s : string) : VersionFile =
+        use stream = new MemoryStream ()
+        let writer = new StreamWriter (stream)
+        writer.Write s
+        writer.Flush ()
+        stream.Seek (0L, SeekOrigin.Begin) |> ignore
+        let reader = new StreamReader (stream)
+        VersionFile.read reader
+
+    let serialise (file : VersionFile) : string =
+        use stream = new MemoryStream ()
+        let writer = new StreamWriter (stream)
+        VersionFile.write writer file
+        writer.Flush ()
+        stream.Seek (0L, SeekOrigin.Begin) |> ignore
+        let reader = new StreamReader (stream)
+        reader.ReadToEnd ()
+
+    [<TestCase(true, true)>]
+    [<TestCase(true, false)>]
+    [<TestCase(false, true)>]
+    [<TestCase(false, false)>]
+    let ``Can parse version file`` (hasPathFilters : bool, hasComment : bool) =
+        let pathFilters = if hasPathFilters then "[\".\"]" else "null"
+        let comment = if hasComment then "// comment here\n" else ""
+
+        sprintf
+            """%s{
+  %s"version": "4.0",
+  "publicReleaseRefSpec": %s[
+    "^refs/heads/main$"
+  ],
+  "pathFilters": %s
+}"""
+            comment
+            comment
+            comment
+            pathFilters
+        |> parse
+        |> shouldEqual
+            {
+                Version = "4.0"
+                PublicReleaseRefSpec = [ "^refs/heads/main$" ]
+                PathFilters = if hasPathFilters then Some [ "." ] else None
+            }
+
+    let versionFiles =
+        List.allPairs
+            [ [] ; [ "^refs/heads/main$" ] ; [ "foo" ; "bar" ] ]
+            [
+                None
+                Some []
+                Some [ "pathFilter1" ]
+                Some [ "pathFilter1" ; "pathFilter2" ]
+            ]
+        |> List.allPairs [ "4.0" ; "5.3" ]
+        |> List.map (fun (version, (refSpec, pathFilters)) ->
+            {
+                Version = version
+                PublicReleaseRefSpec = refSpec
+                PathFilters = pathFilters
+            }
+        )
+        |> List.map TestCaseData
+
+    [<TestCaseSource "versionFiles">]
+    let ``Can write version file`` (versionFile : VersionFile) =
+        versionFile |> serialise |> parse |> shouldEqual versionFile

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -51,7 +51,7 @@ module private VersionFileConverter =
 
             if String.Equals (propertyName, "version", comparer) then
                 match version with
-                | Some existingVersion -> raise (JsonException ("Version property supplied multiple times"))
+                | Some _existingVersion -> raise (JsonException ("Version property supplied multiple times"))
                 | None ->
                     if not (reader.Read ()) then
                         raise (JsonException ())
@@ -64,7 +64,7 @@ module private VersionFileConverter =
                     read options &reader (Some version) publicReleaseRefSpec pathFilters
             elif String.Equals (propertyName, "publicReleaseRefSpec", comparer) then
                 match publicReleaseRefSpec with
-                | Some _ -> raise (JsonException "publicReleaseRefSpec property supplied multiple times")
+                | Some _existing -> raise (JsonException "publicReleaseRefSpec property supplied multiple times")
                 | None ->
                     let arr =
                         JsonSerializer.Deserialize<string array> (&reader, options) |> Array.toList
@@ -144,18 +144,14 @@ module VersionFile =
                 IgnoreNullValues = false
             )
 
-        options.Converters.Add (VersionFileConverter ())
 
         JsonSerializer.Deserialize<VersionFile> (reader.ReadToEnd (), options)
 
     /// Write a version file into a stream.
     let write (writer : StreamWriter) (versionFile : VersionFile) : unit =
         let options = JsonSerializerOptions (WriteIndented = true)
-        options.Converters.Add (VersionFileConverter ())
 
-        versionFile
-        //|> VersionFileSerialised.ofVersionFile
-        |> fun vf -> JsonSerializer.Serialize (vf, options)
+        JsonSerializer.Serialize (versionFile, options)
         |> writer.Write
 
     /// Find version.json files referenced within this assembly.

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -1,13 +1,123 @@
 namespace ApiSurface
 
+open System
+open System.Collections.Generic
 open System.IO
 open System.IO.Abstractions
 open System.Text.Json
 open System.Text.Json.Serialization
 open System.Reflection
 
+module private VersionFileConverter =
+    let rec read
+        (options : JsonSerializerOptions)
+        (reader : Utf8JsonReader byref)
+        (version : string option)
+        (publicReleaseRefSpec : string list option)
+        (pathFilters : string list option)
+        : string * string list * string list option
+        =
+        match reader.TokenType with
+        | JsonTokenType.Comment ->
+            match options.ReadCommentHandling with
+            | JsonCommentHandling.Skip -> read options &reader version publicReleaseRefSpec pathFilters
+            | JsonCommentHandling.Allow ->
+                raise (ArgumentException "JsonCommentHandling.Allow is forbidden when reading JSON.")
+            | JsonCommentHandling.Disallow ->
+                raise (
+                    JsonException (
+                        "Encountered a comment, but JsonCommentHandling is set to Disallow. Set to Skip if comments should be handled."
+                    )
+                )
+            | _ ->
+                raise (
+                    ArgumentOutOfRangeException (
+                        sprintf "Unexpected enum value for JsonCommentHandling: %O" options.ReadCommentHandling
+                    )
+                )
+        | JsonTokenType.EndObject ->
+            match version, publicReleaseRefSpec with
+            | Some version, Some publicReleaseRefSpec -> version, publicReleaseRefSpec, pathFilters
+            | _, _ -> raise (JsonException "Both fields `version` and `publicReleaseRefSpec` are mandatory.")
+        | JsonTokenType.PropertyName ->
+            let propertyName =
+                let s = reader.GetString ()
+
+                if options.PropertyNameCaseInsensitive then
+                    s.ToLowerInvariant ()
+                else
+                    s
+
+            match propertyName with
+            | "version" ->
+                match version with
+                | Some existingVersion -> raise (JsonException ("Version property supplied multiple times"))
+                | None ->
+                    if not (reader.Read ()) then
+                        raise (JsonException ())
+
+                    let version = reader.GetString ()
+
+                    if not (reader.Read ()) then
+                        raise (JsonException ())
+
+                    read options &reader (Some version) publicReleaseRefSpec pathFilters
+            | "publicReleaseRefSpec" ->
+                match publicReleaseRefSpec with
+                | Some _ -> raise (JsonException "publicReleaseRefSpec property supplied multiple times")
+                | None ->
+                    let arr =
+                        JsonSerializer.Deserialize<string array> (&reader, options) |> Array.toList
+
+                    if not (reader.Read ()) then
+                        raise (JsonException ())
+
+                    read options &reader version (Some arr) pathFilters
+            | "pathFilters" ->
+                match pathFilters with
+                | Some _ -> raise (JsonException "pathFilters property supplied multiple times")
+                | None ->
+                    let arr =
+                        JsonSerializer.Deserialize<string array> (&reader, options)
+                        |> Option.ofObj
+                        |> Option.map Array.toList
+
+                    if not (reader.Read ()) then
+                        raise (JsonException ())
+
+                    read options &reader version publicReleaseRefSpec arr
+            | _ -> raise (JsonException (sprintf "Unexpected property %s" propertyName))
+        | _ -> raise (JsonException (sprintf "Unexpected token type %O" reader.TokenType))
+
+
+type private VersionFileConverter () =
+    inherit JsonConverter<VersionFile> ()
+
+    override this.Read (reader : Utf8JsonReader byref, ty : Type, options : JsonSerializerOptions) : VersionFile =
+        if reader.TokenType <> JsonTokenType.StartObject then
+            raise (JsonException "VersionFile should be a JSON object")
+
+        if not (reader.Read ()) then
+            raise (JsonException ())
+
+        let version, publicReleaseRefSpec, pathFilters =
+            VersionFileConverter.read options &reader None None None
+
+        {
+            Version = version
+            PublicReleaseRefSpec = publicReleaseRefSpec
+            PathFilters = pathFilters
+        }
+
+    override this.Write (writer : Utf8JsonWriter, value : VersionFile, options : JsonSerializerOptions) : unit =
+        let dto = Dictionary<string, obj> ()
+        dto.["version"] <- value.Version
+        dto.["publicReleaseRefSpec"] <- value.PublicReleaseRefSpec |> List.toArray
+        dto.["pathFilters"] <- value.PathFilters |> Option.map List.toArray |> Option.toObj
+        JsonSerializer.Serialize (writer, dto, options)
+
 /// A record representing the layout of a version.json file, e.g. as consumed by NerdBank.GitVersioning.
-type VersionFile =
+and [<JsonConverter(typeof<VersionFileConverter>)>] VersionFile =
     {
         /// The version number (e.g. "1.0.1")
         [<JsonPropertyName("version")>]
@@ -18,7 +128,7 @@ type VersionFile =
         PublicReleaseRefSpec : string list
         /// The collection of paths which are to be considered relevant to this package.
         [<JsonPropertyName("pathFilters")>]
-        PathFilters : string list
+        PathFilters : string list option
     }
 
 [<RequireQualifiedAccess>]
@@ -27,14 +137,25 @@ module VersionFile =
     /// Read and parse a stream representing a version file.
     let read (reader : StreamReader) : VersionFile =
         let options =
-            JsonSerializerOptions (ReadCommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true)
+            JsonSerializerOptions (
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true,
+                IgnoreNullValues = false
+            )
+
+        options.Converters.Add (VersionFileConverter ())
 
         JsonSerializer.Deserialize<VersionFile> (reader.ReadToEnd (), options)
 
     /// Write a version file into a stream.
     let write (writer : StreamWriter) (versionFile : VersionFile) : unit =
         let options = JsonSerializerOptions (WriteIndented = true)
-        JsonSerializer.Serialize (versionFile, options) |> writer.Write
+        options.Converters.Add (VersionFileConverter ())
+
+        versionFile
+        //|> VersionFileSerialised.ofVersionFile
+        |> fun vf -> JsonSerializer.Serialize (vf, options)
+        |> writer.Write
 
     /// Find version.json files referenced within this assembly.
     let findVersionFiles (fs : IFileSystem) (assembly : Assembly) : IFileInfo list =

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -151,8 +151,7 @@ module VersionFile =
     let write (writer : StreamWriter) (versionFile : VersionFile) : unit =
         let options = JsonSerializerOptions (WriteIndented = true)
 
-        JsonSerializer.Serialize (versionFile, options)
-        |> writer.Write
+        JsonSerializer.Serialize (versionFile, options) |> writer.Write
 
     /// Find version.json files referenced within this assembly.
     let findVersionFiles (fs : IFileSystem) (assembly : Assembly) : IFileInfo list =

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -41,16 +41,15 @@ module private VersionFileConverter =
             | Some version, Some publicReleaseRefSpec -> version, publicReleaseRefSpec, pathFilters
             | _, _ -> raise (JsonException "Both fields `version` and `publicReleaseRefSpec` are mandatory.")
         | JsonTokenType.PropertyName ->
-            let propertyName =
-                let s = reader.GetString ()
+            let propertyName = reader.GetString ()
 
+            let comparer =
                 if options.PropertyNameCaseInsensitive then
-                    s.ToLowerInvariant ()
+                    StringComparison.InvariantCultureIgnoreCase
                 else
-                    s
+                    StringComparison.InvariantCulture
 
-            match propertyName with
-            | "version" ->
+            if String.Equals (propertyName, "version", comparer) then
                 match version with
                 | Some existingVersion -> raise (JsonException ("Version property supplied multiple times"))
                 | None ->
@@ -63,7 +62,7 @@ module private VersionFileConverter =
                         raise (JsonException ())
 
                     read options &reader (Some version) publicReleaseRefSpec pathFilters
-            | "publicReleaseRefSpec" ->
+            elif String.Equals (propertyName, "publicReleaseRefSpec", comparer) then
                 match publicReleaseRefSpec with
                 | Some _ -> raise (JsonException "publicReleaseRefSpec property supplied multiple times")
                 | None ->
@@ -74,7 +73,7 @@ module private VersionFileConverter =
                         raise (JsonException ())
 
                     read options &reader version (Some arr) pathFilters
-            | "pathFilters" ->
+            elif String.Equals (propertyName, "pathFilters", comparer) then
                 match pathFilters with
                 | Some _ -> raise (JsonException "pathFilters property supplied multiple times")
                 | None ->
@@ -87,7 +86,8 @@ module private VersionFileConverter =
                         raise (JsonException ())
 
                     read options &reader version publicReleaseRefSpec arr
-            | _ -> raise (JsonException (sprintf "Unexpected property %s" propertyName))
+            else
+                raise (JsonException (sprintf "Unexpected property %s" propertyName))
         | _ -> raise (JsonException (sprintf "Unexpected token type %O" reader.TokenType))
 
 

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -8,7 +8,10 @@ open System.Text.Json
 open System.Text.Json.Serialization
 open System.Reflection
 
+[<RequireQualifiedAccess>]
 module private VersionFileConverter =
+    // This function has to live in its own module, because of the restrictions on passing
+    // byrefs to inner functions.
     let rec read
         (options : JsonSerializerOptions)
         (reader : Utf8JsonReader byref)
@@ -24,11 +27,9 @@ module private VersionFileConverter =
             | JsonCommentHandling.Allow ->
                 raise (ArgumentException "JsonCommentHandling.Allow is forbidden when reading JSON.")
             | JsonCommentHandling.Disallow ->
-                raise (
-                    JsonException (
-                        "Encountered a comment, but JsonCommentHandling is set to Disallow. Set to Skip if comments should be handled."
-                    )
-                )
+                JsonException
+                    "Encountered a comment, but JsonCommentHandling is set to Disallow. Set to Skip if comments should be handled."
+                |> raise
             | _ ->
                 raise (
                     ArgumentOutOfRangeException (

--- a/ApiSurface/version.json
+++ b/ApiSurface/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "4.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],


### PR DESCRIPTION
I don't know for sure whether we want this, but it seems better practice to depend on System.Text.Json (which is The Future™) than Newtonsoft.Json. For this PR I've picked the earliest version of System.Text.Json, and it appears to be compatible with a test project that uses 6.0.7, but I also don't know what the best practice is for System.Text.Json and what its forward-compatibility guarantees are.

Note that our dependency, NuGet.Packaging, depends on Newtonsoft.Json anyway, so this doesn't get rid of a dependency.

I've tested this on net481, as well, and found it to work - but it did require all the custom converter nonsense, because until net5 System.Text.Json couldn't deal with F# records, and it *still* can't deal with private types so I couldn't work around that with a private DTO object.