### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # See: https://help.github.com/articles/about-codeowners/
 
-* @G-Research/rqf @G-Research/GR-OSS
+* @G-Research/rqf @G-Research/gr-oss


### PR DESCRIPTION
Team names verified to be correct:

<img width="164" alt="Screenshot 2022-11-17 at 14 31 30" src="https://user-images.githubusercontent.com/3138005/202473604-ef103c4e-cba1-4721-96c4-1c438a24448d.png">

<img width="145" alt="Screenshot 2022-11-17 at 14 32 11" src="https://user-images.githubusercontent.com/3138005/202473758-e891c160-8ab1-47ce-81ab-172cee230a34.png">
