### PR TITLE
Add history to clone during release

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -62,7 +62,8 @@ jobs:
     needs: [all-required-checks-complete]
     environment: release
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
       - name: Setup .NET SDK v6.0.x


### PR DESCRIPTION
Deployment was failing because NerdBank.GitVersioning couldn't see history.