### PR TITLE
Make README more explicit in several places

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,6 @@ Similarly, if an updated version of your library should be published only when c
 
 If you are multi-targetting and you wish for different `SurfaceBaseline.txt` files for each target, you should generate `SurfaceBaseline` files for each target (renaming them to follow the naming schema as described in this README's description of the `ApiSurface` module), and include them all in the project file.
 
-### The version.json file
-
-Add a version.json file to the root of the project, following [NerdBank.GitVersioning] convention.
-
 ### Within the unit test project
 
 Add a reference to the `ApiSurface` NuGet package.


### PR DESCRIPTION
This makes the "how to get started" more explicitly a quick overview, and points to a fleshed-out fully worked example later in the file.

I consider this to be the final blocker before we flip the repo to Public, by the way.