### PR TITLE
Skip Dependabot upgrades for FSharp.Core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,6 @@ updates:
     directory: "/ApiSurface"
     schedule:
       interval: "weekly"
-
+    ignore:
+      # Target the lowest version of FSharp.Core, for max compat
+      - dependency-name: "FSharp.Core"


### PR DESCRIPTION
We specifically chose this version.