### PR TITLE
Use System.Text.Json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/ApiSurface"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -37,7 +37,7 @@ jobs:
       with:
         dotnet-version: ${{matrix.dotnet.sdk}}
     - name: Restore dependencies
-      run: dotnet restore -pTargetFramework=${{matrix.dotnet.framework}}
+      run: dotnet restore '/p:TargetFramework=${{matrix.dotnet.framework}}'
     - name: Build
       run: dotnet build --no-restore --framework=${{matrix.dotnet.framework}}
     - name: Test

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -27,6 +27,8 @@ jobs:
           - { sdk: 7.0.x, framework: net7.0 }
 
     runs-on: ${{matrix.os}}
+    env:
+      CI_TEST_FRAMEWORK: ${{matrix.dotnet.framework}}
 
     steps:
     - uses: actions/checkout@v3
@@ -37,11 +39,11 @@ jobs:
       with:
         dotnet-version: ${{matrix.dotnet.sdk}}
     - name: Restore dependencies
-      run: dotnet restore '/p:TargetFramework=${{matrix.dotnet.framework}}'
+      run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore --framework=${{matrix.dotnet.framework}}
+      run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --framework=${{matrix.dotnet.framework}}
+      run: dotnet test --no-build --verbosity normal
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -29,8 +29,6 @@ jobs:
             dotnet: { sdk: 6.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
-    env:
-      CI_TEST_FRAMEWORK: ${{matrix.dotnet.framework}}
 
     steps:
     - uses: actions/checkout@v3
@@ -45,7 +43,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --framework ${{matrix.dotnet.framework}}
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 env:
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
@@ -18,6 +19,12 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        dotnet:
+          - 2.1.x
+          - 3.1.x
+          - 5.0.x
+          - 6.0.x
+          - 7.0.x
 
     runs-on: ${{matrix.os}}
 
@@ -28,7 +35,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: ${{matrix.dotnet}}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -43,6 +43,11 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: .NET Framework test
+      if: ${{ matrix.os == 'windows-latest' }}
+      env:
+        CI_TEST_FRAMEWORK: net481
+      run: dotnet clean && dotnet test --verbosity normal
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -44,10 +44,10 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: .NET Framework test
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-latest' && matrix.dotnet.sdk == '6.0.x' }}
       env:
         CI_TEST_FRAMEWORK: net481
-      run: dotnet clean && dotnet test --verbosity normal
+      run: dotnet clean && dotnet restore && dotnet build --no-restore && dotnet test --no-build --verbosity normal
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -24,6 +24,9 @@ jobs:
           - { sdk: 5.0.x, framework: net5.0 }
           - { sdk: 6.0.x, framework: net6.0 }
           - { sdk: 7.0.x, framework: net7.0 }
+        include:
+          - os: windows-latest
+            dotnet: { sdk: 6.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
     env:
@@ -43,14 +46,6 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Clean for .NET Framework
-      if: ${{ matrix.os == 'windows-latest' && matrix.dotnet.sdk == '6.0.x' }}
-      run: dotnet clean
-    - name: .NET Framework test
-      if: ${{ matrix.os == 'windows-latest' && matrix.dotnet.sdk == '6.0.x' }}
-      env:
-        CI_TEST_FRAMEWORK: net481
-      run: dotnet restore && dotnet build --no-restore && dotnet test --no-build --verbosity normal
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -43,11 +43,14 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: Clean for .NET Framework
+      if: ${{ matrix.os == 'windows-latest' && matrix.dotnet.sdk == '6.0.x' }}
+      run: dotnet clean
     - name: .NET Framework test
       if: ${{ matrix.os == 'windows-latest' && matrix.dotnet.sdk == '6.0.x' }}
       env:
         CI_TEST_FRAMEWORK: net481
-      run: dotnet clean && dotnet restore && dotnet build --no-restore && dotnet test --no-build --verbosity normal
+      run: dotnet restore && dotnet build --no-restore && dotnet test --no-build --verbosity normal
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,11 +20,11 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - 2.1.x
-          - 3.1.x
-          - 5.0.x
-          - 6.0.x
-          - 7.0.x
+          - { sdk: 2.1.x, framework: netcoreapp2.1 }
+          - { sdk: 3.1.x, framework: netcoreapp3.1 }
+          - { sdk: 5.0.x, framework: net5.0 }
+          - { sdk: 6.0.x, framework: net6.0 }
+          - { sdk: 7.0.x, framework: net7.0 }
 
     runs-on: ${{matrix.os}}
 
@@ -35,13 +35,13 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{matrix.dotnet}}
+        dotnet-version: ${{matrix.dotnet.sdk}}
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore -pTargetFramework=${{matrix.dotnet.framework}}
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --framework=${{matrix.dotnet.framework}}
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --framework=${{matrix.dotnet.framework}}
 
   check-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,7 +20,6 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 2.1.x, framework: netcoreapp2.1 }
           - { sdk: 3.1.x, framework: netcoreapp3.1 }
           - { sdk: 5.0.x, framework: net5.0 }
           - { sdk: 6.0.x, framework: net6.0 }

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.2" />
     <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
     <PackageReference Include="NuGet.Packaging" Version="5.11.2" />
     <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />

--- a/ApiSurface/SurfaceBaseline.txt
+++ b/ApiSurface/SurfaceBaseline.txt
@@ -98,11 +98,11 @@ ApiSurface.SurfaceComparisonModule.AssertIdentical [static method]: ApiSurface.S
 ApiSurface.SurfaceComparisonModule.AssertNoneRemoved [static method]: bool -> ApiSurface.SurfaceComparison -> unit
 ApiSurface.SurfaceComparisonModule.RemovedSymbols [static method]: ApiSurface.SurfaceComparison -> string list
 ApiSurface.VersionFile inherit obj, implements ApiSurface.VersionFile System.IEquatable, System.Collections.IStructuralEquatable, ApiSurface.VersionFile System.IComparable, System.IComparable, System.Collections.IStructuralComparable
-ApiSurface.VersionFile..ctor [constructor]: (string, string list, string list)
-ApiSurface.VersionFile.get_PathFilters [method]: unit -> string list
+ApiSurface.VersionFile..ctor [constructor]: (string, string list, string list option)
+ApiSurface.VersionFile.get_PathFilters [method]: unit -> string list option
 ApiSurface.VersionFile.get_PublicReleaseRefSpec [method]: unit -> string list
 ApiSurface.VersionFile.get_Version [method]: unit -> string
-ApiSurface.VersionFile.PathFilters [property]: [read-only] string list
+ApiSurface.VersionFile.PathFilters [property]: [read-only] string list option
 ApiSurface.VersionFile.PublicReleaseRefSpec [property]: [read-only] string list
 ApiSurface.VersionFile.Version [property]: [read-only] string
 ApiSurface.VersionFileModule inherit obj

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,9 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(CI_TEST_FRAMEWORK)'!=''">
-    <TargetFramework>$(CI_TEST_FRAMEWORK)</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(CI_TEST_FRAMEWORK)'==''">
-    <TargetFramework>net6.0</TargetFramework>
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net481;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <IsPublishable>false</IsPublishable>

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
@@ -12,6 +12,7 @@
     <Compile Include="TestApiSurface.fs" />
     <Compile Include="TestMonotonicVersion.fs" />
     <Compile Include="TestType.fs" />
+    <Compile Include="TestVersionFile.fs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(CI_TEST_FRAMEWORK)'!=''">
+    <TargetFramework>$(CI_TEST_FRAMEWORK)</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(CI_TEST_FRAMEWORK)'==''">
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net481;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>

--- a/ApiSurface/Test/TestVersionFile.fs
+++ b/ApiSurface/Test/TestVersionFile.fs
@@ -1,0 +1,78 @@
+﻿namespace ApiSurface.Test
+
+open System.IO
+open ApiSurface
+open NUnit.Framework
+open FsUnitTyped
+
+[<TestFixture>]
+module TestVersionFile =
+
+    let parse (s : string) : VersionFile =
+        use stream = new MemoryStream ()
+        let writer = new StreamWriter (stream)
+        writer.Write s
+        writer.Flush ()
+        stream.Seek (0L, SeekOrigin.Begin) |> ignore
+        let reader = new StreamReader (stream)
+        VersionFile.read reader
+
+    let serialise (file : VersionFile) : string =
+        use stream = new MemoryStream ()
+        let writer = new StreamWriter (stream)
+        VersionFile.write writer file
+        writer.Flush ()
+        stream.Seek (0L, SeekOrigin.Begin) |> ignore
+        let reader = new StreamReader (stream)
+        reader.ReadToEnd ()
+
+    [<TestCase(true, true)>]
+    [<TestCase(true, false)>]
+    [<TestCase(false, true)>]
+    [<TestCase(false, false)>]
+    let ``Can parse version file`` (hasPathFilters : bool, hasComment : bool) =
+        let pathFilters = if hasPathFilters then "[\".\"]" else "null"
+        let comment = if hasComment then "// comment here\n" else ""
+
+        sprintf
+            """%s{
+  %s"version": "4.0",
+  "publicReleaseRefSpec": %s[
+    "^refs/heads/main$"
+  ],
+  "pathFilters": %s
+}"""
+            comment
+            comment
+            comment
+            pathFilters
+        |> parse
+        |> shouldEqual
+            {
+                Version = "4.0"
+                PublicReleaseRefSpec = [ "^refs/heads/main$" ]
+                PathFilters = if hasPathFilters then Some [ "." ] else None
+            }
+
+    let versionFiles =
+        List.allPairs
+            [ [] ; [ "^refs/heads/main$" ] ; [ "foo" ; "bar" ] ]
+            [
+                None
+                Some []
+                Some [ "pathFilter1" ]
+                Some [ "pathFilter1" ; "pathFilter2" ]
+            ]
+        |> List.allPairs [ "4.0" ; "5.3" ]
+        |> List.map (fun (version, (refSpec, pathFilters)) ->
+            {
+                Version = version
+                PublicReleaseRefSpec = refSpec
+                PathFilters = pathFilters
+            }
+        )
+        |> List.map TestCaseData
+
+    [<TestCaseSource "versionFiles">]
+    let ``Can write version file`` (versionFile : VersionFile) =
+        versionFile |> serialise |> parse |> shouldEqual versionFile

--- a/ApiSurface/Test/TestVersionFile.fs
+++ b/ApiSurface/Test/TestVersionFile.fs
@@ -26,12 +26,9 @@ module TestVersionFile =
         let reader = new StreamReader (stream)
         reader.ReadToEnd ()
 
-    [<TestCase(true, true)>]
-    [<TestCase(true, false)>]
-    [<TestCase(false, true)>]
-    [<TestCase(false, false)>]
-    let ``Can parse version file`` (hasPathFilters : bool, hasComment : bool) =
-        let pathFilters = if hasPathFilters then "[\".\"]" else "null"
+    [<TestCase true>]
+    [<TestCase false>]
+    let ``Can parse version file with path filters`` (hasComment : bool) =
         let comment = if hasComment then "// comment here\n" else ""
 
         sprintf
@@ -40,18 +37,65 @@ module TestVersionFile =
   "publicReleaseRefSpec": %s[
     "^refs/heads/main$"
   ],
-  "pathFilters": %s
+  "pathFilters": ["."]
 }"""
             comment
             comment
             comment
-            pathFilters
         |> parse
         |> shouldEqual
             {
                 Version = "4.0"
                 PublicReleaseRefSpec = [ "^refs/heads/main$" ]
-                PathFilters = if hasPathFilters then Some [ "." ] else None
+                PathFilters = Some [ "." ]
+            }
+
+    [<TestCase true>]
+    [<TestCase false>]
+    let ``Can parse version file with null path filters`` (hasComment : bool) =
+        let comment = if hasComment then "// comment here\n" else ""
+
+        sprintf
+            """%s{
+  %s"version": "4.0",
+  "publicReleaseRefSpec": %s[
+    "^refs/heads/main$"
+  ],
+  "pathFilters": null
+}"""
+            comment
+            comment
+            comment
+        |> parse
+        |> shouldEqual
+            {
+                Version = "4.0"
+                PublicReleaseRefSpec = [ "^refs/heads/main$" ]
+                PathFilters = None
+            }
+
+
+    [<TestCase true>]
+    [<TestCase false>]
+    let ``Can parse version file with omitted path filters`` (hasComment : bool) =
+        let comment = if hasComment then "// comment here\n" else ""
+
+        sprintf
+            """%s{
+  %s"version": "4.0",
+  "publicReleaseRefSpec": %s[
+    "^refs/heads/main$"
+  ]
+}"""
+            comment
+            comment
+            comment
+        |> parse
+        |> shouldEqual
+            {
+                Version = "4.0"
+                PublicReleaseRefSpec = [ "^refs/heads/main$" ]
+                PathFilters = None
             }
 
     let versionFiles =

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -25,7 +25,6 @@ module VersionFile =
         JsonSerializerOptions (
             ReadCommentHandling = JsonCommentHandling.Skip,
             AllowTrailingCommas = true,
-            IgnoreNullValues = false,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         )
 

--- a/ApiSurface/VersionFile.fs
+++ b/ApiSurface/VersionFile.fs
@@ -10,14 +10,11 @@ open System.Text.Json.Serialization
 type VersionFile =
     {
         /// The version number (e.g. "1.0")
-        [<JsonPropertyName "version">]
         Version : string
         /// The collection of Git references which are to be considered relevant to this package.
         /// For example, "^refs/heads/main$".
-        [<JsonPropertyName "publicReleaseRefSpec">]
         PublicReleaseRefSpec : string list
         /// The collection of paths which are to be considered relevant to this package.
-        [<JsonPropertyName "pathFilters">]
         PathFilters : string list option
     }
 
@@ -28,10 +25,12 @@ module VersionFile =
         JsonSerializerOptions (
             ReadCommentHandling = JsonCommentHandling.Skip,
             AllowTrailingCommas = true,
-            IgnoreNullValues = false
+            IgnoreNullValues = false,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         )
 
-    let private writeOptions = JsonSerializerOptions (WriteIndented = true)
+    let private writeOptions =
+        JsonSerializerOptions (WriteIndented = true, PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
 
     /// Read and parse a stream representing a version file.
     let read (reader : StreamReader) : VersionFile =

--- a/ApiSurface/version.json
+++ b/ApiSurface/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "4.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ For the complete list of supported frameworks and file names, see the private `f
 
 ## Compatibility notes
 
-Automatic verification and updating of `version.json` is not supported on the .NET Framework and perhaps on older versions of .NET Core, because the version of `System.Text.Json` in those SDKs lacks the ability to serialise F# records.
-You may find that it works anyway if you manually update to a sufficiently high `System.Text.Json` version.
+This project is untested on the .NET Framework; if it works on e.g. net481, this is purely by coincidence.
+Similarly, netcoreapp2.1 and earlier are untested.
 
 ## Fully worked end-to-end example
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ If you wish to make this specific to .NET Framework or .NET Core, you should the
 
 For the complete list of supported frameworks and file names, see the private `frameworkBaselineFile : string` in the `ApiSurface` module.
 
+## Compatibility notes
+
+Automatic verification and updating of `version.json` is not supported on the .NET Framework and perhaps on older versions of .NET Core, because the version of `System.Text.Json` in those SDKs lacks the ability to serialise F# records.
+You may find that it works anyway if you manually update to a sufficiently high `System.Text.Json` version.
+
 ## Fully worked end-to-end example
 
 Assumptions for this example:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ For the complete list of supported frameworks and file names, see the private `f
 
 ## Compatibility notes
 
-This project is untested on the .NET Framework; if it works on e.g. net481, this is purely by coincidence.
-Similarly, netcoreapp2.1 and earlier are untested.
+This project is untested on older versions of the .NET Framework and of .NET Core; check the GitHub Actions test matrix to see the platforms on which the tests run.
 
 ## Fully worked end-to-end example
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestFeature"
-  }
-}


### PR DESCRIPTION
This is like https://github.com/G-Research/ApiSurface/pull/5, but instead of working around old versions of System.Text.Json, we just move up to one that supports F#.

This PR also adds many more test target frameworks, so that we are explicit about what is supported. In order to do this, I had to delete the `global.json`, but then I don't think we really care what build tooling we use here.

Note that this doesn't remove our dependency on Newtonsoft.Json, because that's still transitively pulled in through our use of NuGet.Packaging.