### PR TITLE
Add package information to output string

### DIFF
--- a/ApiSurface/MonotonicVersion.fs
+++ b/ApiSurface/MonotonicVersion.fs
@@ -22,7 +22,7 @@ module MonotonicVersion =
 
         inner 1
 
-    let validateVersion (currentVersion : NuGetVersion) (latestVersion : NuGetVersion) (packageId : string) =
+    let validateVersion (packageId : string) (currentVersion : NuGetVersion) (latestVersion : NuGetVersion) =
         let latestVersion = NuGetVersion (latestVersion.Major, latestVersion.Minor, 0)
         let latestVersionStr = latestVersion.Version.ToString 2
 
@@ -50,9 +50,9 @@ module MonotonicVersion =
     /// Checks to make sure that either the minor version has increased by at most 1, or the major version has increased by at most 1.
     /// If both have updated or one has updated by more than 1 then it suggests a mistake has been made.
     let versionIncreaseIsInAcceptableRange
+        (packageId : string)
         (currentVersion : NuGetVersion)
         (latestVersion : NuGetVersion)
-        (packageId : string)
         =
         let majorDiff = currentVersion.Major - latestVersion.Major
         let minorDiff = currentVersion.Minor - latestVersion.Minor
@@ -136,8 +136,8 @@ module MonotonicVersion =
         match List.tryHead versions with
         | None -> printfn "Found no public versions of package '%s'" packageId
         | Some latestVersion ->
-            validateVersion currentVersion latestVersion packageId
-            versionIncreaseIsInAcceptableRange currentVersion latestVersion packageId
+            validateVersion packageId currentVersion latestVersion
+            versionIncreaseIsInAcceptableRange packageId currentVersion latestVersion
 
     [<CompiledName "Validate">]
     let validate (assembly : Assembly) (packageId : string) =

--- a/ApiSurface/MonotonicVersion.fs
+++ b/ApiSurface/MonotonicVersion.fs
@@ -22,19 +22,21 @@ module MonotonicVersion =
 
         inner 1
 
-    let validateVersion (currentVersion : NuGetVersion) (latestVersion : NuGetVersion) =
+    let validateVersion (currentVersion : NuGetVersion) (latestVersion : NuGetVersion) (packageId : string) =
         let latestVersion = NuGetVersion (latestVersion.Major, latestVersion.Minor, 0)
         let latestVersionStr = latestVersion.Version.ToString 2
 
         if currentVersion >= latestVersion then
             printfn
-                "Version specified in version.json (%O) is >= the latest version in the NuGet repository (%s)"
+                "Version of '%s' specified in version.json (%O) is >= the latest version in the NuGet repository (%s)"
+                packageId
                 currentVersion
                 latestVersionStr
         else
             [
                 sprintf
-                    "Version specified in version.json (%O) is less than the latest version in the NuGet repository (%s)"
+                    "Version of '%s' specified in version.json (%O) is less than the latest version in the NuGet repository (%s)"
+                    packageId
                     currentVersion
                     latestVersionStr
                 ""
@@ -47,7 +49,11 @@ module MonotonicVersion =
 
     /// Checks to make sure that either the minor version has increased by at most 1, or the major version has increased by at most 1.
     /// If both have updated or one has updated by more than 1 then it suggests a mistake has been made.
-    let versionIncreaseIsInAcceptableRange (currentVersion : NuGetVersion) (latestVersion : NuGetVersion) =
+    let versionIncreaseIsInAcceptableRange
+        (currentVersion : NuGetVersion)
+        (latestVersion : NuGetVersion)
+        (packageId : string)
+        =
         let majorDiff = currentVersion.Major - latestVersion.Major
         let minorDiff = currentVersion.Minor - latestVersion.Minor
         let latestVersion = NuGetVersion (latestVersion.Major, latestVersion.Minor, 0)
@@ -58,13 +64,15 @@ module MonotonicVersion =
 
         if acceptableMajorIncrease || acceptableMinorIncrease then
             printfn
-                "Version specified in version.json (%O) is >= the latest version in the NuGet repository by an acceptable amount (%s)"
+                "Version of '%s' specified in version.json (%O) is >= the latest version in the NuGet repository by an acceptable amount (%s)"
+                packageId
                 currentVersion
                 latestVersionStr
         else
             [
                 sprintf
-                    "Version specified in version.json (%O) is larger than the latest version in the NuGet repository (%s) by an unacceptable amount"
+                    "Version of '%s' specified in version.json (%O) is larger than the latest version in the NuGet repository (%s) by an unacceptable amount"
+                    packageId
                     currentVersion
                     latestVersionStr
                 ""
@@ -128,8 +136,8 @@ module MonotonicVersion =
         match List.tryHead versions with
         | None -> printfn "Found no public versions of package '%s'" packageId
         | Some latestVersion ->
-            validateVersion currentVersion latestVersion
-            versionIncreaseIsInAcceptableRange currentVersion latestVersion
+            validateVersion currentVersion latestVersion packageId
+            versionIncreaseIsInAcceptableRange currentVersion latestVersion packageId
 
     [<CompiledName "Validate">]
     let validate (assembly : Assembly) (packageId : string) =

--- a/ApiSurface/MonotonicVersion.fsi
+++ b/ApiSurface/MonotonicVersion.fsi
@@ -8,10 +8,10 @@ open NuGet.Versioning
 module MonotonicVersion =
 
     val internal validateVersion :
-        currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> packageId : string -> unit
+        packageId : string -> currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> unit
 
     val internal versionIncreaseIsInAcceptableRange :
-        currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> packageId : string -> unit
+        packageId : string -> currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> unit
 
     /// Ensure the version in version.json is increasing monotonically
     [<CompiledName "Validate">]

--- a/ApiSurface/MonotonicVersion.fsi
+++ b/ApiSurface/MonotonicVersion.fsi
@@ -7,10 +7,11 @@ open NuGet.Versioning
 [<RequireQualifiedAccess>]
 module MonotonicVersion =
 
-    val internal validateVersion : currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> unit
+    val internal validateVersion :
+        currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> packageId : string -> unit
 
     val internal versionIncreaseIsInAcceptableRange :
-        currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> unit
+        currentVersion : NuGetVersion -> latestVersion : NuGetVersion -> packageId : string -> unit
 
     /// Ensure the version in version.json is increasing monotonically
     [<CompiledName "Validate">]

--- a/ApiSurface/Test/TestMonotonicVersion.fs
+++ b/ApiSurface/Test/TestMonotonicVersion.fs
@@ -11,26 +11,26 @@ module TestMonotonicVersion =
 
     [<Test>]
     let ``Patch version is ignored when comparing versions`` () =
-        MonotonicVersion.validateVersion (v "11.0") (v "11.0.123")
+        MonotonicVersion.validateVersion (v "11.0") (v "11.0.123") "MyCoolPackage"
 
     [<Test>]
     let ``Exact match is valid`` () =
-        MonotonicVersion.validateVersion (v "11.0") (v "11.0.0")
+        MonotonicVersion.validateVersion (v "11.0") (v "11.0.0") "MyCoolPackage"
 
     [<Test>]
     let ``Minor increase of 1 is valid`` () =
-        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.1") (v "11.0.0")
+        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.1") (v "11.0.0") "MyCoolPackage"
 
     [<Test>]
     let ``Major increase of 1 is valid`` () =
-        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.0") (v "11.1.0")
+        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.0") (v "11.1.0") "MyCoolPackage"
 
     [<Test>]
     let ``Minor increase of 2 is invalid`` () =
         Assert.Throws (
             Has.Message.StartsWith
-                "Version specified in version.json (11.2) is larger than the latest version in the NuGet repository (11.0) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.2") (v "11.0.0")
+                "Version of 'MyCoolPackage' specified in version.json (11.2) is larger than the latest version in the NuGet repository (11.0) by an unacceptable amount",
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.2") (v "11.0.0") "MyCoolPackage"
         )
         |> ignore
 
@@ -38,8 +38,8 @@ module TestMonotonicVersion =
     let ``Major increase of 2 is invalid`` () =
         Assert.Throws (
             Has.Message.StartsWith
-                "Version specified in version.json (13.0) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "13.0") (v "11.1.0")
+                "Version of 'MyCoolPackage' specified in version.json (13.0) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "13.0") (v "11.1.0") "MyCoolPackage"
         )
         |> ignore
 
@@ -47,8 +47,8 @@ module TestMonotonicVersion =
     let ``Major and Minor increase of 1 is invalid`` () =
         Assert.Throws (
             Has.Message.StartsWith
-                "Version specified in version.json (12.2) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.2") (v "11.1.0")
+                "Version of 'MyCoolPackage' specified in version.json (12.2) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.2") (v "11.1.0") "MyCoolPackage"
         )
         |> ignore
 
@@ -56,7 +56,7 @@ module TestMonotonicVersion =
     let ``Decreasing version throws`` () =
         Assert.Throws (
             Has.Message.StartsWith
-                "Version specified in version.json (11.0) is less than the latest version in the NuGet repository (11.1)",
-            fun () -> MonotonicVersion.validateVersion (v "11.0") (v "11.1.0")
+                "Version of 'MyCoolPackage' specified in version.json (11.0) is less than the latest version in the NuGet repository (11.1)",
+            fun () -> MonotonicVersion.validateVersion (v "11.0") (v "11.1.0") "MyCoolPackage"
         )
         |> ignore

--- a/ApiSurface/Test/TestMonotonicVersion.fs
+++ b/ApiSurface/Test/TestMonotonicVersion.fs
@@ -11,26 +11,26 @@ module TestMonotonicVersion =
 
     [<Test>]
     let ``Patch version is ignored when comparing versions`` () =
-        MonotonicVersion.validateVersion (v "11.0") (v "11.0.123") "MyCoolPackage"
+        MonotonicVersion.validateVersion "MyCoolPackage" (v "11.0") (v "11.0.123")
 
     [<Test>]
     let ``Exact match is valid`` () =
-        MonotonicVersion.validateVersion (v "11.0") (v "11.0.0") "MyCoolPackage"
+        MonotonicVersion.validateVersion "MyCoolPackage" (v "11.0") (v "11.0.0")
 
     [<Test>]
     let ``Minor increase of 1 is valid`` () =
-        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.1") (v "11.0.0") "MyCoolPackage"
+        MonotonicVersion.versionIncreaseIsInAcceptableRange "MyCoolPackage" (v "11.1") (v "11.0.0")
 
     [<Test>]
     let ``Major increase of 1 is valid`` () =
-        MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.0") (v "11.1.0") "MyCoolPackage"
+        MonotonicVersion.versionIncreaseIsInAcceptableRange "MyCoolPackage" (v "12.0") (v "11.1.0")
 
     [<Test>]
     let ``Minor increase of 2 is invalid`` () =
         Assert.Throws (
             Has.Message.StartsWith
                 "Version of 'MyCoolPackage' specified in version.json (11.2) is larger than the latest version in the NuGet repository (11.0) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "11.2") (v "11.0.0") "MyCoolPackage"
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange "MyCoolPackage" (v "11.2") (v "11.0.0")
         )
         |> ignore
 
@@ -39,7 +39,7 @@ module TestMonotonicVersion =
         Assert.Throws (
             Has.Message.StartsWith
                 "Version of 'MyCoolPackage' specified in version.json (13.0) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "13.0") (v "11.1.0") "MyCoolPackage"
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange "MyCoolPackage" (v "13.0") (v "11.1.0")
         )
         |> ignore
 
@@ -48,7 +48,7 @@ module TestMonotonicVersion =
         Assert.Throws (
             Has.Message.StartsWith
                 "Version of 'MyCoolPackage' specified in version.json (12.2) is larger than the latest version in the NuGet repository (11.1) by an unacceptable amount",
-            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange (v "12.2") (v "11.1.0") "MyCoolPackage"
+            fun () -> MonotonicVersion.versionIncreaseIsInAcceptableRange "MyCoolPackage" (v "12.2") (v "11.1.0")
         )
         |> ignore
 
@@ -57,6 +57,6 @@ module TestMonotonicVersion =
         Assert.Throws (
             Has.Message.StartsWith
                 "Version of 'MyCoolPackage' specified in version.json (11.0) is less than the latest version in the NuGet repository (11.1)",
-            fun () -> MonotonicVersion.validateVersion (v "11.0") (v "11.1.0") "MyCoolPackage"
+            fun () -> MonotonicVersion.validateVersion "MyCoolPackage" (v "11.0") (v "11.1.0")
         )
         |> ignore


### PR DESCRIPTION
If you have lots of these tests in a solution, this makes it a little easier to see which ones are failing.