### PR TITLE
Use correct string comparisons

### DIFF
--- a/ApiSurface/ApiSurface.fs
+++ b/ApiSurface/ApiSurface.fs
@@ -1,5 +1,6 @@
 ﻿namespace ApiSurface
 
+open System
 open System.IO.Abstractions
 open System.Text.RegularExpressions
 open System.Runtime.CompilerServices
@@ -33,9 +34,9 @@ module ApiSurface =
     let private frameworkBaselineFile =
         let desc = RuntimeInformation.FrameworkDescription
 
-        if desc.StartsWith ".NET Core" then
+        if desc.StartsWith (".NET Core", StringComparison.Ordinal) then
             "SurfaceBaseline-NetCore.txt"
-        elif desc.StartsWith ".NET Framework" then
+        elif desc.StartsWith (".NET Framework", StringComparison.Ordinal) then
             "SurfaceBaseline-NetFramework.txt"
         else
             // e.g. "SurfaceBaseline-Net5.txt"

--- a/ApiSurface/Assembly.fs
+++ b/ApiSurface/Assembly.fs
@@ -1,5 +1,6 @@
 namespace ApiSurface
 
+open System
 open System.IO
 open System.Reflection
 
@@ -16,7 +17,7 @@ module internal Assembly =
             |> Seq.toList
             |> List.choose (fun i -> i.Namespace |> Option.ofObj)
             |> Set.ofList
-            |> Set.filter (fun i -> i.StartsWith "<" |> not)
+            |> Set.filter (fun i -> i.StartsWith ("<", StringComparison.Ordinal) |> not)
             |> Set.add (assembly.GetName().Name)
 
         namespaces

--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -80,7 +80,7 @@ module DocCoverage =
 
         // op_xyz$W methods are written to the xml file without the $W suffix
         let trimmedName =
-            if methInfo.Name.EndsWith "$W" then
+            if methInfo.Name.EndsWith ("$W", StringComparison.Ordinal) then
                 methInfo.Name.Substring (0, methInfo.Name.Length - 2)
             else
                 methInfo.Name
@@ -156,7 +156,8 @@ module DocCoverage =
                         let methInfo = mi :?> MethodInfo
 
                         not methInfo.IsSpecialName
-                        || (not (mi.Name.StartsWith "get_") && not (mi.Name.StartsWith "set_"))
+                        || (not (mi.Name.StartsWith ("get_", StringComparison.Ordinal))
+                            && not (mi.Name.StartsWith ("set_", StringComparison.Ordinal)))
 
                     // Skip nested types of F# unions - they're compiler
                     // generated (so cannot be commented), although not
@@ -176,7 +177,7 @@ module DocCoverage =
                 // Skip modules which have a corresponding type
                 let optionalTypeDoc =
                     let searchName =
-                        if t.FullName.EndsWith "Module" then
+                        if t.FullName.EndsWith ("Module", StringComparison.Ordinal) then
                             t.FullName.Substring (0, t.FullName.Length - 6)
                         else
                             t.FullName
@@ -201,7 +202,7 @@ module DocCoverage =
                     else
 
                     match mi.MemberType with
-                    | MemberTypes.Method when isUnion && mi.Name.StartsWith "New" ->
+                    | MemberTypes.Method when isUnion && mi.Name.StartsWith ("New", StringComparison.Ordinal) ->
                         // Strip the 'New' prefix and make this member a nested
                         // type instead
                         [
@@ -355,7 +356,7 @@ module DocCoverage =
                 // Skip backing-fields of class properties.
                 // These are private, but the F# compiler emits them in the XML
                 // documentation anyway.
-                not (memberName.EndsWith "@")
+                not (memberName.EndsWith ("@", StringComparison.Ordinal))
             )
             |> Set.ofSeq
             |> Members.UnknownAccess


### PR DESCRIPTION
I recently discovered that `String.StartsWith` and friends are all by default wrong. (See https://learn.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings for general guidance.) I don't know if it's possible for a method name to contain ASCII control characters, for example, but it's certainly possible for filenames to.