### PR TITLE
Bump NuGet.{Protocol,Packaging} from 6.6.1 to 6.7.0

### DIFF
--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -36,8 +36,8 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="6.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="6.6.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.6.1" />
+    <PackageReference Include="NuGet.Packaging" Version="6.7.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.7.0" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />
   </ItemGroup>
 </Project>

--- a/ApiSurface/Test/Sample.fs
+++ b/ApiSurface/Test/Sample.fs
@@ -239,5 +239,8 @@ module Sample =
             "T:ApiSurface.DocumentationSample.MyModule.someInnerLambda@107"
             "M:ApiSurface.DocumentationSample.MyModule.someInnerLambda@107.Invoke(System.Int32)"
             "F:ApiSurface.DocumentationSample.MyModule.someInnerLambda@107.x"
+            // github.com/G-Research/ApiSurface/pull/40 saw this on macOS net7.0.
+            // I was unable to reproduce it locally.
+            "F:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.value__"
         ]
         |> Set.ofList


### PR DESCRIPTION
Supersedes #38, #39. It looks like these have to be bumped together.