### PR TITLE
Analyzers integration

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.15.0",
+      "version": "0.16.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "fantomas"
       ]
+    },
+    "fsharp-analyzers": {
+      "version": "0.15.0",
+      "commands": [
+        "fsharp-analyzers"
+      ]
     }
   }
 }

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -77,7 +77,11 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./ApiSurface/ApiSurface.fsproj
       - name: Run analyzers
-        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.5/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.5/ --verbose --report ./analysis.sarif --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: analysis.sarif
 
   nuget-pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./ApiSurface/ApiSurface.fsproj
       - name: Run analyzers
-        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.4/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001 --exclude-analyzer PartialAppAnalyzer
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.5/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
 
   nuget-pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, analyzers_integration ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./ApiSurface/ApiSurface.fsproj
       - name: Run analyzers
-        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.3/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.4/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001 --exclude-analyzer PartialAppAnalyzer
 
   nuget-pack:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET SDK v6.0.x

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -59,6 +59,26 @@ jobs:
       - name: Run Fantomas
         run: ./hooks/pre-push
 
+  analyze-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup .NET SDK v6.0.x
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Prepare .NET tools
+        run: dotnet tool restore
+      - name: Prepare analyzers
+        run: dotnet restore ./analyzers/analyzers.fsproj
+      - name: Restore dependencies
+        run: dotnet restore ./ApiSurface/ApiSurface.fsproj
+      - name: Run analyzers
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.3/ --verbose --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+
   nuget-pack:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -2,7 +2,7 @@ name: .NET
 
 on:
   push:
-    branches: [ main, analyzers_integration ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -113,7 +113,7 @@ jobs:
         run: if [[ $(find . -maxdepth 1 -name 'ApiSurface.*.nupkg' -printf c | wc -c) -ne "1" ]]; then exit 1; fi
 
   all-required-checks-complete:
-    needs: [check-format, build, expected-pack]
+    needs: [check-format, build, expected-pack, analyze-code]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All required checks complete."

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 .idea/
 *.sln.DotSettings.user
+.analyzerpackages

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ riderModule.iml
 .idea/
 *.sln.DotSettings.user
 .analyzerpackages
+analysis.sarif

--- a/ApiSurface/Type.fs
+++ b/ApiSurface/Type.fs
@@ -1,6 +1,7 @@
 namespace ApiSurface
 
 open System
+open System.Globalization
 open FSharp.Reflection
 
 /// Associated helper functions for handling System.Type objects.
@@ -98,7 +99,10 @@ module internal Type =
             |> sprintf "(%s)"
             |> sprintf
                 "%s%s"
-                (if t.Name.StartsWith "ValueTuple" && t.Namespace = "System" then
+                (if
+                     t.Name.StartsWith ("ValueTuple", false, CultureInfo.InvariantCulture)
+                     && t.Namespace = "System"
+                 then
                      "struct "
                  else
                      "")

--- a/ApiSurface/Type.fs
+++ b/ApiSurface/Type.fs
@@ -100,7 +100,7 @@ module internal Type =
             |> sprintf
                 "%s%s"
                 (if
-                     t.Name.StartsWith ("ValueTuple", false, CultureInfo.InvariantCulture)
+                     t.Name.StartsWith ("ValueTuple", StringComparison.Ordinal)
                      && t.Namespace = "System"
                  then
                      "struct "

--- a/ApiSurface/Type.fs
+++ b/ApiSurface/Type.fs
@@ -1,7 +1,6 @@
 namespace ApiSurface
 
 open System
-open System.Globalization
 open FSharp.Reflection
 
 /// Associated helper functions for handling System.Type objects.

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.Build.NoTargets/1.0.80"> <!-- This is not a project we want to build. -->
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <RestorePackagesPath>../.analyzerpackages/</RestorePackagesPath> <!-- Changes the global packages folder-->
+    <!-- <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath> --> <!-- It's still PackageReference, so project intermediates are still created. -->
+    <TargetFramework>net6.0</TargetFramework> <!-- This is not super relevant, as long as your SDK version supports it. -->
+    <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder> <!-- If a package is resolved to a fallback folder, it may not be downloaded.-->
+    <AutomaticallyUseReferenceAssemblyPackages>false</AutomaticallyUseReferenceAssemblyPackages> <!-- We don't want to build this project, so we do not need the reference assemblies for the framework we chose.-->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.3]" />
+  </ItemGroup>
+
+</Project>
+

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.3]" />
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.4]" />
   </ItemGroup>
 
 </Project>

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.4]" />
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.5]" />
   </ItemGroup>
 
 </Project>

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <RestorePackagesPath>../.analyzerpackages/</RestorePackagesPath> <!-- Changes the global packages folder-->
     <!-- <MSBuildProjectExtensionsPath>$(RestorePackagesPath)obj/</MSBuildProjectExtensionsPath> --> <!-- It's still PackageReference, so project intermediates are still created. -->
     <TargetFramework>net6.0</TargetFramework> <!-- This is not super relevant, as long as your SDK version supports it. -->


### PR DESCRIPTION
This PR adds the G-Research analyzers to the pipeline as a dedicated job and silences a warning about a `StartsWith` usage.
We could add the analyzers run as steps to the `build` job instead of having a dedicated job for it, but as `check-format` has it's own dedicated job, I thought this would be more in line with the current practice.

The added `./analyzers/analyzers.fsproj` is currently the easiest way to get the DLL files of the analyzers to a known place.