### PR TITLE
Fix the net7 output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 .idea/
 *.sln.DotSettings.user
+.DS_Store

--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -99,7 +99,8 @@ module DocCoverage =
         let types =
             assembly.GetTypes ()
             |> Array.filter (fun ty ->
-                // Skip the new code-analysis types added in net7
+                // Skip the new code-analysis types added in net7 (discussion ongoing: see
+                // https://github.com/dotnet/runtime/issues/93699 )
                 not (ty.FullName.StartsWith ("System.Diagnostics.CodeAnalysis.Dynamic", StringComparison.Ordinal))
             )
 

--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -96,7 +96,12 @@ module DocCoverage =
 
     [<CompiledName "FromAssemblySurface">]
     let ofAssemblySurface (assembly : Assembly) : DocCoverage =
-        let types = assembly.GetTypes () |> Array.ofSeq
+        let types =
+            assembly.GetTypes ()
+            |> Array.filter (fun ty ->
+                // Skip the new code-analysis types added in net7
+                not (ty.FullName.StartsWith ("System.Diagnostics.CodeAnalysis.Dynamic", StringComparison.Ordinal))
+            )
 
         let getSourceConstructFlags (compilationMapping : CompilationMappingAttribute) =
             if obj.ReferenceEquals (compilationMapping, null) then


### PR DESCRIPTION
I have no idea why these types have started appearing (haven't even tried to work it out). ApiSurface itself starts exporting the following items, which this PR works around:

```
F:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.value__
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.Interfaces
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicConstructors
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicEvents
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicFields
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicMethods
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicNestedTypes
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.NonPublicProperties
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicConstructors
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicFields
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicMethods
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicNestedTypes
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
P:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties
T:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute
T:System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes
```

I think this must be a bug in the SDK; raised https://github.com/dotnet/fsharp/issues/16141 .