### PR TITLE
Actual fix for compiler-generated types

### DIFF
--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -99,10 +99,12 @@ module DocCoverage =
         let types =
             assembly.GetTypes ()
             |> Array.filter (fun ty ->
-                // Skip the new code-analysis types added in net7 (discussion ongoing: see
-                // https://github.com/dotnet/runtime/issues/93699 )
+                // A version of the F# compiler in 7.0.400 emitted some generated types which were not marked
+                // as compiler-generated. Skip those.
+                // https://github.com/dotnet/fsharp/issues/16141
                 not (ty.FullName.StartsWith ("System.Diagnostics.CodeAnalysis.Dynamic", StringComparison.Ordinal))
             )
+            |> Array.filter (fun ty -> obj.ReferenceEquals (ty.GetCustomAttribute<CompilerGeneratedAttribute> (), null))
 
         let getSourceConstructFlags (compilationMapping : CompilationMappingAttribute) =
             if obj.ReferenceEquals (compilationMapping, null) then

--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -99,12 +99,12 @@ module DocCoverage =
         let types =
             assembly.GetTypes ()
             |> Array.filter (fun ty ->
+                obj.ReferenceEquals (ty.GetCustomAttribute<CompilerGeneratedAttribute> (), null)
                 // A version of the F# compiler in 7.0.400 emitted some generated types which were not marked
                 // as compiler-generated. Skip those.
                 // https://github.com/dotnet/fsharp/issues/16141
-                not (ty.FullName.StartsWith ("System.Diagnostics.CodeAnalysis.Dynamic", StringComparison.Ordinal))
+                && not (ty.FullName.StartsWith ("System.Diagnostics.CodeAnalysis.Dynamic", StringComparison.Ordinal))
             )
-            |> Array.filter (fun ty -> obj.ReferenceEquals (ty.GetCustomAttribute<CompilerGeneratedAttribute> (), null))
 
         let getSourceConstructFlags (compilationMapping : CompilationMappingAttribute) =
             if obj.ReferenceEquals (compilationMapping, null) then


### PR DESCRIPTION
Since there is a bad SDK out there, we can't get rid of the hack, but we can at least implement the correct fix.