### PR TITLE
Fix version-file truncation

### DIFF
--- a/ApiSurface/ApiSurface.fs
+++ b/ApiSurface/ApiSurface.fs
@@ -205,7 +205,7 @@ module ApiSurface =
                 Version = sprintf "%d.%d" version.Major version.Minor
             }
 
-        use writer = versionFile.OpenWrite ()
+        use writer = versionFile.Open FileMode.Create
         use writer = new StreamWriter (writer)
         updatedFile |> VersionFile.write writer
 

--- a/ApiSurface/ApiSurface.fsi
+++ b/ApiSurface/ApiSurface.fsi
@@ -58,3 +58,6 @@ module ApiSurface =
     val writeAssemblyBaselineWithDirectory : string -> Assembly -> unit
 
     val internal findNewVersion : Version -> baseline : ApiSurface -> target : ApiSurface -> Version
+
+    val internal updateVersionJson :
+        baseline : ApiSurface -> Assembly -> versionFile : System.IO.Abstractions.IFileInfo -> unit

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -7,6 +7,7 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="RedirectOutput.fs" />
     <Compile Include="Sample.fs" />
     <Compile Include="TestDocCoverage.fs" />
     <Compile Include="TestSemanticVersioning.fs" />

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -18,11 +18,13 @@
     <Compile Include="TestVersionFile.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FsCheck" Version="2.16.6" />
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="FsUnit" Version="3.4.0" />
     <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="4.2.13" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />

--- a/ApiSurface/Test/RedirectOutput.fs
+++ b/ApiSurface/Test/RedirectOutput.fs
@@ -1,0 +1,35 @@
+namespace ApiSurface.Test
+
+open System
+open System.IO
+open System.Text
+open System.Threading
+
+type RedirectOutput () =
+    let mutable original = Unchecked.defaultof<_>
+    let substitute = new MemoryStream ()
+    let writer = new StreamWriter (substitute)
+
+    do
+        let isLocked = Interlocked.Increment (RedirectOutput.IsLocked : int ref)
+
+        if isLocked = 1 then
+            original <- Console.Out
+            Console.SetOut writer
+        else
+            failwith "Attempted to use RedirectOutput twice in parallel"
+
+    member this.GetText () =
+        substitute.ToArray () |> Encoding.UTF8.GetString
+
+    static member val private IsLocked = ref 0
+
+    interface IDisposable with
+        member _.Dispose () =
+            Console.SetOut original
+            writer.Dispose ()
+            substitute.Dispose ()
+            let isUnlocked = Interlocked.Decrement RedirectOutput.IsLocked
+
+            if isUnlocked <> 0 then
+                failwithf "RedirectOutput lock was somehow still held after disposal: %i" isUnlocked

--- a/ApiSurface/Test/TestVersionFile.fs
+++ b/ApiSurface/Test/TestVersionFile.fs
@@ -147,6 +147,8 @@ module TestVersionFile =
 
     [<Test>]
     let ``version JSON file can be written`` () =
+        use standardOutput = new RedirectOutput ()
+
         let property (versionFile : VersionFile) =
             let fs = MockFileSystem ()
             let location = fs.FileInfo.FromFileName "version.json"


### PR DESCRIPTION
Fixes #42.

(The version history is meaningful, if you want to review commit-by-commit.)