### PR TITLE
Enable GitHub release

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -141,3 +141,20 @@ jobs:
           name: nuget-package
       - name: Publish to NuGet
         run: dotnet nuget push "ApiSurface.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+
+  github-release:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
+    needs: [all-required-checks-complete]
+    environment: release
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download NuGet artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: nuget-package
+    - uses: ncipollo/release-action@v1
+      with:
+        artifacts: "ApiSurface/bin/Release/ApiSurface.*.nupkg"


### PR DESCRIPTION
The goal of this PR is to add a release job with a target for GitHub
The Nuget Release job is already present, the same package/artifacts are used to publish it to the GitHub release

https://github.com/G-Research/oss-portfolio-maturity/issues/332