### PR TITLE
Add experimental F# compiler flags

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningLevel>4</WarningLevel>
     <DebugType>embedded</DebugType>
+    <!-- improve F# compilation speed -->
+    <!-- FS0075: The command-line option 'parallelreferenceresolution' is for test purposes only -->
+    <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen --warnaserror-:75 --nowarn:75 --parallelreferenceresolution</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" PrivateAssets="all" />


### PR DESCRIPTION
Ran `dotnet build -c Release --no-restore --no-incremental -tl`:

Before: `5.5s`
After: `3.8s`