### PR TITLE
Move code format/lint to GitHub CI for transparency

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Run Fantomas
-        run: ./hooks/pre-push
+        run: dotnet tool run fantomas --check .
 
   analyze-code:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The goal of this PR is to save `./hooks/pre-hook` as is for local purpose, but for transparency same check is moved to be part of `check-format` job