### PR TITLE
Fix SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
@@ -20,15 +20,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com" />
   </ItemGroup>
-  <!--
-    SourceLink doesn't support F# deterministic builds out of the box,
-    so tell SourceLink that our source root is going to be remapped.
-  -->
-  <Target Name="MapSourceRoot" BeforeTargets="_GenerateSourceLinkFile" Condition="'$(SourceRootMappedPathsFeatureSupported)' != 'true'">
-    <ItemGroup>
-      <SourceRoot Update="@(SourceRoot)">
-        <MappedPath>Z:\CheckoutRoot\ApiSurface\</MappedPath>
-      </SourceRoot>
-    </ItemGroup>
-  </Target>
+  <PropertyGroup Condition="'$(GITHUB_ACTION)' != ''">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The `MapSourceRoot` target here is *ancient*. This all works out of the box now. Verified using https://github.com/Smaug123/nuget-metadata that the source mappings are correct when the GITHUB_ACTION env var is set (we get links like  /_//ApiSurface/ApiSurface.fs to https://raw.githubusercontent.com/G-Research/ApiSurface/c1e01a8f03ffe4b0eaae137baf981ae05aa77745//ApiSurface/ApiSurface.fs), and when the env var is not set (i.e. locally, when we get proper links relative to the source files on your actual computer).

See https://docs.github.com/en/actions/learn-github-actions/variables for verification that GITHUB_ACTION is set.

Fixes #1 .