### PR TITLE
Drop support for net3, net5, net7

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,10 +20,8 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 3.1.x, framework: netcoreapp3.1 }
-          - { sdk: 5.0.x, framework: net5.0 }
           - { sdk: 6.0.x, framework: net6.0 }
-          - { sdk: 7.0.x, framework: net7.0 }
+          - { sdk: 8.0.x, framework: net8.0 }
         include:
           - os: windows-latest
             dotnet: { sdk: 6.0.x, framework: net481 }

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net481;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Looks like net3 and net5 have started failing on macOS (see https://github.com/G-Research/ApiSurface/pull/70); I'm not inclined to put any effort into fixing them. Net7 goes out of support in two weeks, so I've dropped that while I'm at it.