### PR TITLE
Stop warning about dependencies during build

### DIFF
--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -12,6 +12,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>semver;packaging;documentation;version</PackageTags>
+    <!-- "Package %s has a known high severity vulnerability" -->
+    <!-- We're a library; it's on our consumers to make sure they
+         are using nonvulnerable dependencies if they care.-->
+    <NoWarn>NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -12,10 +12,6 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>semver;packaging;documentation;version</PackageTags>
-    <!-- "Package %s has a known high severity vulnerability" -->
-    <!-- We're a library; it's on our consumers to make sure they
-         are using nonvulnerable dependencies if they care.-->
-    <NoWarn>NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -41,7 +37,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <!-- "Package %s has a known high severity vulnerability" -->
+    <!-- We're a library; it's on our consumers to make sure they
+         are using nonvulnerable dependencies if they care.
+         System.Text.Json is highly backward-compatible. -->
+    <PackageReference Include="System.Text.Json" Version="7.0.3" NoWarn="%(NoWarn);NU1903" />
     <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.10.1" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="TestVersionFile.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Update="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="FsCheck" Version="2.16.6" />
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />


### PR DESCRIPTION
NuGet has recently started erroring when you take dependencies on packages with security advisories. This is unhelpful for a library; NuGet's dependency resolution algorithm means we don't have the final say on what transitive versions our consumers use, so it's up to them. System.Text.Json is highly backward compatible and is part of the runtime, so like FSharp.Core it's correct to specify the lowest version in libraries and trust that a later version will appear in our consumers.