### PR TITLE
Upgrade test dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "6.0.0",
+      "version": "6.3.10",
       "commands": [
         "fantomas"
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.16.0",
+      "version": "0.26.1",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 updates:
 

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./ApiSurface/ApiSurface.fsproj
       - name: Run analyzers
-        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/*/ --verbose --report ./analysis.sarif --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/*/ --verbosity diag --report ./analysis.sarif --treat-as-error GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: .NET
 
 on:
@@ -75,7 +76,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ./ApiSurface/ApiSurface.fsproj
       - name: Run analyzers
-        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/0.1.5/ --verbose --report ./analysis.sarif --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
+        run: dotnet fsharp-analyzers --project ./ApiSurface/ApiSurface.fsproj --analyzers-path ./.analyzerpackages/g-research.fsharp.analyzers/*/ --verbose --report ./analysis.sarif --fail-on-warnings GRA-STRING-001 GRA-STRING-002 GRA-STRING-003 GRA-UNIONCASE-001
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -12,6 +12,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>semver;packaging;documentation;version</PackageTags>
+    <!-- "Package %s has a known high severity vulnerability" -->
+    <!-- We're a library; it's on our consumers to make sure they
+         are using nonvulnerable dependencies if they care.-->
+    <NoWarn>NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/ApiSurface/ApiSurface.fsproj
+++ b/ApiSurface/ApiSurface.fsproj
@@ -12,10 +12,6 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageTags>semver;packaging;documentation;version</PackageTags>
-    <!-- "Package %s has a known high severity vulnerability" -->
-    <!-- We're a library; it's on our consumers to make sure they
-         are using nonvulnerable dependencies if they care.-->
-    <NoWarn>NU1903</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -41,7 +37,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <!-- "Package %s has a known high severity vulnerability" -->
+    <!-- We're a library; it's on our consumers to make sure they
+         are using nonvulnerable dependencies if they care.
+         System.Text.Json is highly backward-compatible. -->
+    <PackageReference Include="System.Text.Json" Version="7.0.3" NoWarn="%(NoWarn);NU1903" />
     <PackageReference Include="NuGet.Packaging" Version="6.10.1" />
     <PackageReference Include="NuGet.Protocol" Version="6.10.1" />
     <PackageReference Include="System.IO.Abstractions" Version="4.2.13" />

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -20,12 +20,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Update="System.Text.Json" Version="8.0.4" />
-    <PackageReference Include="FsCheck" Version="2.16.6" />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="FsUnit" Version="3.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="FsCheck" Version="3.0.0-rc3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="FsUnit" Version="6.0.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="4.2.13" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="TestVersionFile.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Update="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="FsCheck" Version="2.16.6" />
     <PackageReference Include="FSharp.Core" Version="4.3.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />

--- a/ApiSurface/Test/TestApiSurface.fs
+++ b/ApiSurface/Test/TestApiSurface.fs
@@ -1,7 +1,7 @@
 ﻿namespace ApiSurface.Test
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open ApiSurface
 
 [<TestFixture>]
@@ -16,15 +16,12 @@ module TestApiSurface =
 
         let expected = Sample.publicSurface
 
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test toString`` () =
 
-        [ "Foo" ; "Bar" ]
-        |> ApiSurface
-        |> ApiSurface.toString
-        |> should equal "Foo\nBar"
+        [ "Foo" ; "Bar" ] |> ApiSurface |> ApiSurface.toString |> shouldEqual "Foo\nBar"
 
     [<Test>]
     let ``Test compare for identical surfaces`` () =
@@ -44,36 +41,38 @@ module TestApiSurface =
 
     [<Test>]
     let ``Test compare for different surfaces (not in baseline)`` () =
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                [ "Bar" ; "Foo" ]
+                |> ApiSurface
+                |> ApiSurface.compare (ApiSurface [ "Foo" ])
+                |> SurfaceComparison.assertIdentical
+            )
 
-        fun () ->
-            [ "Bar" ; "Foo" ]
-            |> ApiSurface
-            |> ApiSurface.compare (ApiSurface [ "Foo" ])
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) have been added (i.e. are NOT present in the baseline):\n  + Bar\n")
-            typeof<exn>
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) have been added (i.e. are NOT present in the baseline):\n  + Bar\n"
 
     [<Test>]
     let ``Test compare for different surfaces (not in target)`` () =
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                [ "Foo" ]
+                |> ApiSurface
+                |> ApiSurface.compare (ApiSurface [ "Foo" ; "Bar" ])
+                |> SurfaceComparison.assertIdentical
+            )
 
-        fun () ->
-            [ "Foo" ]
-            |> ApiSurface
-            |> ApiSurface.compare (ApiSurface [ "Foo" ; "Bar" ])
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) have been removed (i.e. are present in the baseline):\n  - Bar\n")
-            typeof<exn>
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) have been removed (i.e. are present in the baseline):\n  - Bar\n"
 
     [<Test>]
     let ``Test ofAssemblyBaseline`` () =
 
         let (ApiSurface actual) = sampleAssembly |> ApiSurface.ofAssemblyBaseline
         let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test ofAssemblyBaselineWithExplicitFilename`` () =
@@ -83,4 +82,4 @@ module TestApiSurface =
             |> ApiSurface.ofAssemblyBaselineWithExplicitResourceName "SurfaceBaseline.txt"
 
         let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected

--- a/ApiSurface/Test/TestDocCoverage.fs
+++ b/ApiSurface/Test/TestDocCoverage.fs
@@ -1,7 +1,7 @@
 namespace ApiSurface.Test
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open ApiSurface
 
 [<TestFixture>]
@@ -23,7 +23,7 @@ module TestDocCoverage =
             |> String.concat "\n"
             |> failwithf "Unexpectedly received members: %s"
 
-        Assert.IsEmpty expectedButAbsent
+        expectedButAbsent |> shouldBeEmpty
 
     [<Test>]
     let ``Test ofAssemblyXml`` () =
@@ -32,7 +32,7 @@ module TestDocCoverage =
 
         let actual = ofXml.Split '\n' |> Set.ofArray
 
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test comparing with identical coverage`` () =
@@ -65,11 +65,13 @@ module TestDocCoverage =
             </doc>
             """
 
-        fun () ->
-            DocCoverage.ofXml "left.xml" left
-            |> DocCoverage.compare (DocCoverage.ofXml "right.xml" right)
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) are only in 'left.xml':\n  + F:ApiSurface.DocumentationSample.Class1.myField\n\nThe following 1 member(s) are only in 'right.xml':\n  - P:ApiSurface.DocumentationSample.Class1.X\n")
-            typeof<exn>
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                DocCoverage.ofXml "left.xml" left
+                |> DocCoverage.compare (DocCoverage.ofXml "right.xml" right)
+                |> SurfaceComparison.assertIdentical
+            )
+
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) are only in 'left.xml':\n  + F:ApiSurface.DocumentationSample.Class1.myField\n\nThe following 1 member(s) are only in 'right.xml':\n  - P:ApiSurface.DocumentationSample.Class1.X\n"

--- a/ApiSurface/Test/TestVersionFile.fs
+++ b/ApiSurface/Test/TestVersionFile.fs
@@ -3,6 +3,7 @@
 open System.IO
 open System.IO.Abstractions.TestingHelpers
 open ApiSurface
+open FsCheck.FSharp
 open NUnit.Framework
 open FsUnitTyped
 open FsCheck
@@ -125,12 +126,12 @@ module TestVersionFile =
 
     let versionFileGen : Gen<VersionFile> =
         gen {
-            let! major = Arb.generate<int>
+            let! major = ArbMap.defaults |> ArbMap.generate<int>
             let major = abs major
-            let! minor = Arb.generate<int>
+            let! minor = ArbMap.defaults |> ArbMap.generate<int>
             let minor = abs minor
-            let! releaseRefSpec = Arb.generate<NonNull<string> list>
-            let! pathFilters = Arb.generate<NonNull<string> list option>
+            let! releaseRefSpec = ArbMap.defaults |> ArbMap.generate<NonNull<string> list>
+            let! pathFilters = ArbMap.defaults |> ArbMap.generate<NonNull<string> list option>
 
             return
                 {

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <OtherFlags>$(OtherFlags) --test:GraphBasedChecking --test:ParallelOptimization --test:ParallelIlxGen --warnaserror-:75 --nowarn:75 --parallelreferenceresolution</OtherFlags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.141" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.githubusercontent.com" />
   </ItemGroup>

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.1.5]" />
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.10.0]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We don't have Dependabot looking at the test project; maybe after I've fixed the path filters stuff, we should.