### PR TITLE
Reduce churn via path filters

### DIFF
--- a/ApiSurface/version.json
+++ b/ApiSurface/version.json
@@ -3,5 +3,17 @@
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],
-  "pathFilters": null
+  "pathFilters": [
+    "/",
+    ":!/hooks",
+    ":!/.editorconfig",
+    ":!/.github",
+    ":!/.config",
+    ":!/analyzers",
+    ":!/ApiSurface/Test",
+    ":!/ApiSurface/SampleAssembly",
+    ":!/ApiSurface/DocumentationSample",
+    ":!/ApiSurface/.git-blame-ignore-revs",
+    ":!/ApiSurface/CONTRIBUTING.md"
+  ]
 }


### PR DESCRIPTION
[Path filter syntax](https://github.com/dotnet/Nerdbank.GitVersioning/blob/81162b84f1e81864d3c79ddfc4ce9794ae065574/doc/pathFilters.md). I've chosen to count all files by default, and block specific files, because it's always a bit hard to know statically what the footprint of a project is.

This should probably go along with a change to special-case the Nuget publish and Git tag/Github release stages to cope with duplicate releases.