### PR TITLE
Bump the SDK and stop building on <net8

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -20,11 +20,7 @@ jobs:
           - macOS-latest
           - windows-latest
         dotnet:
-          - { sdk: 6.0.x, framework: net6.0 }
           - { sdk: 8.0.x, framework: net8.0 }
-        include:
-          - os: windows-latest
-            dotnet: { sdk: 6.0.x, framework: net481 }
 
     runs-on: ${{matrix.os}}
 
@@ -48,10 +44,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Run Fantomas
@@ -64,10 +60,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Prepare .NET tools
         run: dotnet tool restore
       - name: Prepare analyzers
@@ -88,10 +84,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # so that NerdBank.GitVersioning has access to history
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v8.0.x
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Build
         run: dotnet build ApiSurface/ApiSurface.fsproj --configuration Release
       - name: Pack

--- a/ApiSurface.SampleAssembly/SurfaceBaseline.txt
+++ b/ApiSurface.SampleAssembly/SurfaceBaseline.txt
@@ -32,6 +32,7 @@ ApiSurface.SampleAssembly.SampleDU+Bar.Item [property]: [read-only] int
 ApiSurface.SampleAssembly.SampleDU+Tags inherit obj
 ApiSurface.SampleAssembly.SampleDU+Tags.Bar [static field]: int = 1
 ApiSurface.SampleAssembly.SampleDU+Tags.Foo [static field]: int = 0
+ApiSurface.SampleAssembly.SampleDU.Equals [method]: (ApiSurface.SampleAssembly.SampleDU, System.Collections.IEqualityComparer) -> bool
 ApiSurface.SampleAssembly.SampleDU.Foo [static property]: [read-only] ApiSurface.SampleAssembly.SampleDU
 ApiSurface.SampleAssembly.SampleDU.get_Foo [static method]: unit -> ApiSurface.SampleAssembly.SampleDU
 ApiSurface.SampleAssembly.SampleDU.get_IsBar [method]: unit -> bool

--- a/ApiSurface/ApiSurface.fs
+++ b/ApiSurface/ApiSurface.fs
@@ -40,7 +40,7 @@ module ApiSurface =
             "SurfaceBaseline-NetFramework.txt"
         else
             // e.g. "SurfaceBaseline-Net5.txt"
-            let frameworkNumber = Regex("^\\.NET ([0-9]+)\.").Match desc
+            let frameworkNumber = Regex(@"^\.NET ([0-9]+)\.").Match desc
 
             if frameworkNumber.Success then
                 sprintf "SurfaceBaseline-Net%s.txt" frameworkNumber.Groups.[0].Value

--- a/ApiSurface/SurfaceBaseline.txt
+++ b/ApiSurface/SurfaceBaseline.txt
@@ -1,6 +1,7 @@
 ApiSurface.ApiMember inherit obj, implements ApiSurface.ApiMember System.IEquatable, System.Collections.IStructuralEquatable
 ApiSurface.ApiMember..ctor [constructor]: (string, ApiSurface.MemberTypeInfo, System.Type, bool)
 ApiSurface.ApiMember.DeclaringType [property]: [read-only] System.Type
+ApiSurface.ApiMember.Equals [method]: (ApiSurface.ApiMember, System.Collections.IEqualityComparer) -> bool
 ApiSurface.ApiMember.get_DeclaringType [method]: unit -> System.Type
 ApiSurface.ApiMember.get_IsStatic [method]: unit -> bool
 ApiSurface.ApiMember.get_MemberTypeInfo [method]: unit -> ApiSurface.MemberTypeInfo
@@ -12,6 +13,7 @@ ApiSurface.ApiMemberModule inherit obj
 ApiSurface.ApiMemberModule.FromMemberInfo [static method]: System.Reflection.MemberInfo -> ApiSurface.ApiMember
 ApiSurface.ApiMemberModule.Print [static method]: ApiSurface.ApiMember -> string
 ApiSurface.ApiSurface inherit obj, implements ApiSurface.ApiSurface System.IEquatable, System.Collections.IStructuralEquatable, ApiSurface.ApiSurface System.IComparable, System.IComparable, System.Collections.IStructuralComparable
+ApiSurface.ApiSurface.Equals [method]: (ApiSurface.ApiSurface, System.Collections.IEqualityComparer) -> bool
 ApiSurface.ApiSurfaceModule inherit obj
 ApiSurface.ApiSurfaceModule.AssertIdentical [static method]: System.Reflection.Assembly -> unit
 ApiSurface.ApiSurfaceModule.Compare [static method]: ApiSurface.ApiSurface -> ApiSurface.ApiSurface -> ApiSurface.SurfaceComparison
@@ -55,6 +57,7 @@ ApiSurface.MemberTypeInfo+Tags.Event [static field]: int = 4
 ApiSurface.MemberTypeInfo+Tags.Field [static field]: int = 3
 ApiSurface.MemberTypeInfo+Tags.Method [static field]: int = 1
 ApiSurface.MemberTypeInfo+Tags.Property [static field]: int = 2
+ApiSurface.MemberTypeInfo.Equals [method]: (ApiSurface.MemberTypeInfo, System.Collections.IEqualityComparer) -> bool
 ApiSurface.MemberTypeInfo.Event [static property]: [read-only] ApiSurface.MemberTypeInfo
 ApiSurface.MemberTypeInfo.get_Event [static method]: unit -> ApiSurface.MemberTypeInfo
 ApiSurface.MemberTypeInfo.get_IsConstructor [method]: unit -> bool
@@ -79,6 +82,7 @@ ApiSurface.MonotonicVersion.ValidateResource [static method]: string -> System.R
 ApiSurface.PublicType inherit obj, implements ApiSurface.PublicType System.IEquatable, System.Collections.IStructuralEquatable
 ApiSurface.PublicType..ctor [constructor]: (string, System.Type option, System.Type list, ApiSurface.ApiMember list, System.Type)
 ApiSurface.PublicType.BaseClass [property]: [read-only] System.Type option
+ApiSurface.PublicType.Equals [method]: (ApiSurface.PublicType, System.Collections.IEqualityComparer) -> bool
 ApiSurface.PublicType.FullName [property]: [read-only] string
 ApiSurface.PublicType.get_BaseClass [method]: unit -> System.Type option
 ApiSurface.PublicType.get_FullName [method]: unit -> string
@@ -99,6 +103,7 @@ ApiSurface.SurfaceComparisonModule.AssertNoneRemoved [static method]: bool -> Ap
 ApiSurface.SurfaceComparisonModule.RemovedSymbols [static method]: ApiSurface.SurfaceComparison -> string list
 ApiSurface.VersionFile inherit obj, implements ApiSurface.VersionFile System.IEquatable, System.Collections.IStructuralEquatable, ApiSurface.VersionFile System.IComparable, System.IComparable, System.Collections.IStructuralComparable
 ApiSurface.VersionFile..ctor [constructor]: (string, string list, string list option)
+ApiSurface.VersionFile.Equals [method]: (ApiSurface.VersionFile, System.Collections.IEqualityComparer) -> bool
 ApiSurface.VersionFile.get_PathFilters [method]: unit -> string list option
 ApiSurface.VersionFile.get_PublicReleaseRefSpec [method]: unit -> string list
 ApiSurface.VersionFile.get_Version [method]: unit -> string

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net481;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <IsPublishable>false</IsPublishable>

--- a/ApiSurface/Test/ApiSurface.Test.fsproj
+++ b/ApiSurface/Test/ApiSurface.Test.fsproj
@@ -21,11 +21,10 @@
   <ItemGroup>
     <PackageReference Update="System.Text.Json" Version="8.0.4" />
     <PackageReference Include="FsCheck" Version="2.16.6" />
-    <PackageReference Include="FSharp.Core" Version="4.3.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="FsUnit" Version="3.4.0" />
-    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="FsUnit" Version="6.0.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="4.2.13" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />

--- a/ApiSurface/Test/Sample.fs
+++ b/ApiSurface/Test/Sample.fs
@@ -3,7 +3,7 @@ namespace ApiSurface.Test
 [<RequireQualifiedAccess>]
 module Sample =
 
-    let publicSurface =
+    let publicSurface : Set<string> =
         [
             "ApiSurface.SampleAssembly.Class1 inherit obj"
             "ApiSurface.SampleAssembly.Class1..ctor [constructor]: int"
@@ -39,6 +39,7 @@ module Sample =
             "ApiSurface.SampleAssembly.SampleDU+Tags inherit obj"
             "ApiSurface.SampleAssembly.SampleDU+Tags.Bar [static field]: int = 1"
             "ApiSurface.SampleAssembly.SampleDU+Tags.Foo [static field]: int = 0"
+            "ApiSurface.SampleAssembly.SampleDU.Equals [method]: (ApiSurface.SampleAssembly.SampleDU, System.Collections.IEqualityComparer) -> bool"
             "ApiSurface.SampleAssembly.SampleDU.Foo [static property]: [read-only] ApiSurface.SampleAssembly.SampleDU"
             "ApiSurface.SampleAssembly.SampleDU.get_Foo [static method]: unit -> ApiSurface.SampleAssembly.SampleDU"
             "ApiSurface.SampleAssembly.SampleDU.get_IsBar [method]: unit -> bool"
@@ -56,6 +57,7 @@ module Sample =
             "ApiSurface.SampleAssembly.ValueTupleOperations inherit obj"
             "ApiSurface.SampleAssembly.ValueTupleOperations.fst [static method]: struct ('a * 'b) -> 'a"
         ]
+        |> Set.ofList
 
     let allIncludingInternal =
         [

--- a/ApiSurface/Test/TestApiSurface.fs
+++ b/ApiSurface/Test/TestApiSurface.fs
@@ -13,6 +13,7 @@ module TestApiSurface =
     let ``Test ofAssembly`` () =
 
         let (ApiSurface actual) = sampleAssembly |> ApiSurface.ofAssembly
+        let actual = Set.ofList actual
 
         let expected = Sample.publicSurface
 
@@ -73,7 +74,8 @@ module TestApiSurface =
     let ``Test ofAssemblyBaseline`` () =
 
         let (ApiSurface actual) = sampleAssembly |> ApiSurface.ofAssemblyBaseline
-        let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
+        let actual = Set.ofList actual
+        let expected = Sample.publicSurface |> Set.add "Bar" |> Set.add "Foo"
         actual |> shouldEqual expected
 
     [<Test>]
@@ -83,5 +85,7 @@ module TestApiSurface =
             sampleAssembly
             |> ApiSurface.ofAssemblyBaselineWithExplicitResourceName "SurfaceBaseline.txt"
 
-        let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
+        let actual = Set.ofList actual
+
+        let expected = Sample.publicSurface |> Set.add "Bar" |> Set.add "Foo"
         actual |> shouldEqual expected

--- a/ApiSurface/Test/TestApiSurface.fs
+++ b/ApiSurface/Test/TestApiSurface.fs
@@ -1,7 +1,7 @@
-﻿namespace ApiSurface.Test
+namespace ApiSurface.Test
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open ApiSurface
 
 [<TestFixture>]
@@ -16,15 +16,12 @@ module TestApiSurface =
 
         let expected = Sample.publicSurface
 
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test toString`` () =
 
-        [ "Foo" ; "Bar" ]
-        |> ApiSurface
-        |> ApiSurface.toString
-        |> should equal "Foo\nBar"
+        [ "Foo" ; "Bar" ] |> ApiSurface |> ApiSurface.toString |> shouldEqual "Foo\nBar"
 
     [<Test>]
     let ``Test compare for identical surfaces`` () =
@@ -45,35 +42,39 @@ module TestApiSurface =
     [<Test>]
     let ``Test compare for different surfaces (not in baseline)`` () =
 
-        fun () ->
-            [ "Bar" ; "Foo" ]
-            |> ApiSurface
-            |> ApiSurface.compare (ApiSurface [ "Foo" ])
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) have been added (i.e. are NOT present in the baseline):\n  + Bar\n")
-            typeof<exn>
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                [ "Bar" ; "Foo" ]
+                |> ApiSurface
+                |> ApiSurface.compare (ApiSurface [ "Foo" ])
+                |> SurfaceComparison.assertIdentical
+            )
+
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) have been added (i.e. are NOT present in the baseline):\n  + Bar\n"
 
     [<Test>]
     let ``Test compare for different surfaces (not in target)`` () =
 
-        fun () ->
-            [ "Foo" ]
-            |> ApiSurface
-            |> ApiSurface.compare (ApiSurface [ "Foo" ; "Bar" ])
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) have been removed (i.e. are present in the baseline):\n  - Bar\n")
-            typeof<exn>
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                [ "Foo" ]
+                |> ApiSurface
+                |> ApiSurface.compare (ApiSurface [ "Foo" ; "Bar" ])
+                |> SurfaceComparison.assertIdentical
+            )
+
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) have been removed (i.e. are present in the baseline):\n  - Bar\n"
 
     [<Test>]
     let ``Test ofAssemblyBaseline`` () =
 
         let (ApiSurface actual) = sampleAssembly |> ApiSurface.ofAssemblyBaseline
         let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test ofAssemblyBaselineWithExplicitFilename`` () =
@@ -83,4 +84,4 @@ module TestApiSurface =
             |> ApiSurface.ofAssemblyBaselineWithExplicitResourceName "SurfaceBaseline.txt"
 
         let expected = Sample.publicSurface @ [ "Bar" ; "Foo" ]
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected

--- a/ApiSurface/Test/TestDocCoverage.fs
+++ b/ApiSurface/Test/TestDocCoverage.fs
@@ -1,7 +1,7 @@
 namespace ApiSurface.Test
 
 open NUnit.Framework
-open FsUnit
+open FsUnitTyped
 open ApiSurface
 
 [<TestFixture>]
@@ -23,7 +23,7 @@ module TestDocCoverage =
             |> String.concat "\n"
             |> failwithf "Unexpectedly received members: %s"
 
-        Assert.IsEmpty expectedButAbsent
+        expectedButAbsent |> shouldBeEmpty
 
     [<Test>]
     let ``Test ofAssemblyXml`` () =
@@ -32,7 +32,7 @@ module TestDocCoverage =
 
         let actual = ofXml.Split '\n' |> Set.ofArray
 
-        CollectionAssert.AreEqual (expected, actual)
+        actual |> shouldEqual expected
 
     [<Test>]
     let ``Test comparing with identical coverage`` () =
@@ -65,11 +65,13 @@ module TestDocCoverage =
             </doc>
             """
 
-        fun () ->
-            DocCoverage.ofXml "left.xml" left
-            |> DocCoverage.compare (DocCoverage.ofXml "right.xml" right)
-            |> SurfaceComparison.assertIdentical
-        |> should
-            (throwWithMessage
-                "Unexpected difference.\n\nThe following 1 member(s) are only in 'left.xml':\n  + F:ApiSurface.DocumentationSample.Class1.myField\n\nThe following 1 member(s) are only in 'right.xml':\n  - P:ApiSurface.DocumentationSample.Class1.X\n")
-            typeof<exn>
+        let exc =
+            Assert.Throws<exn> (fun () ->
+                DocCoverage.ofXml "left.xml" left
+                |> DocCoverage.compare (DocCoverage.ofXml "right.xml" right)
+                |> SurfaceComparison.assertIdentical
+            )
+
+        exc.Message
+        |> shouldEqual
+            "Unexpected difference.\n\nThe following 1 member(s) are only in 'left.xml':\n  + F:ApiSurface.DocumentationSample.Class1.myField\n\nThe following 1 member(s) are only in 'right.xml':\n  - P:ApiSurface.DocumentationSample.Class1.X\n"

--- a/ApiSurface/version.json
+++ b/ApiSurface/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0",
+  "version": "4.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
https://github.com/dotnet/fsharp/pull/16857 has changed the API surface. ApiSurface has the ability to discriminate surfaces between major versions of .NET, but not minor versions, so I just chose the simplest way of "assume everyone is running net8".