### PR TITLE
Migrate to centrally-managed actions

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -125,9 +125,12 @@ jobs:
 
   all-required-checks-complete:
     needs: [check-format, build, expected-pack, analyze-code, github-tag-and-release-dry-run]
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All required checks complete."
+      - uses: G-Research/common-actions/check-required-lite@main
+        with:
+          needs-context: ${{ toJSON(needs) }}
 
   # This does not gate release, because external dependencies may be flaky.
   markdown-link-check:
@@ -146,8 +149,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: nuget-package
-      - name: Publish to NuGet
-        run: dotnet nuget push "ApiSurface.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          path: downloaded
+      - name: Publish NuGet package
+        uses: G-Research/common-actions/publish-nuget@main
+        with:
+          package-name: ApiSurface
+          nuget-key: ${{ secrets.NUGET_API_KEY }}
+          nupkg-dir: downloaded
 
   github-tag-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
1. Bugfix: the `all-required-checks-complete` action now genuinely does require all checks to succeed (previously it [did not](https://github.com/G-Research/common-actions/tree/main/check-required-lite#why)).
2. Feature: we now perform GitHub attestation on the resulting NuGet package. I'll test this once the new version gets released, with `gh attestation verify --owner G-Research ~/.nuget/packages/apisurface/{newversion}/apisurface.{newversion}.nupkg`.

See https://github.com/G-Research/common-actions

I've tested both these actions under a variety of conditions on my own repos; see, for example, [the all-checks-complete](https://github.com/Smaug123/unofficial-nunit-runner/blob/50948e629c31dfc095d7830e050d521db3de0313/.github/workflows/dotnet.yaml#L281) and [the publish](https://github.com/Smaug123/unofficial-nunit-runner/blob/50948e629c31dfc095d7830e050d521db3de0313/.github/workflows/dotnet.yaml#L352) actions.