### PR TITLE
Fix perms error

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -144,6 +144,10 @@ jobs:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
     needs: [all-required-checks-complete]
     environment: release
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
       - name: Download NuGet artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Error on main:

> Error: Failed to get ID token: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable

I even [documented this](https://github.com/G-Research/common-actions/blob/2b7dc49cb14f3344fbe6019c14a31165e258c059/publish-nuget/README.md#unable-to-get-actions_id_token_request_url-env-variable), suggesting that I've hit this problem before 🤦 

[Here's](https://github.com/Smaug123/WoofWare.Myriad/blob/38f4821fa4ac55b3ac0c6346befb7ec0c69102d1/.github/workflows/dotnet.yaml#L272) an example where I do this correctly.