### PR TITLE
Disable printf on happy path

### DIFF
--- a/ApiSurface/DocCoverage.fs
+++ b/ApiSurface/DocCoverage.fs
@@ -383,4 +383,4 @@ module DocCoverage =
     let assertFullyDocumented (assembly : Assembly) =
         ofAssemblyXml assembly
         |> compare (ofAssemblySurface assembly)
-        |> SurfaceComparison.assertNoneRemoved true
+        |> SurfaceComparison.assertNoneRemoved false


### PR DESCRIPTION
It's just logspam in a successful test run.