### PR TITLE
Control releases with NerdBank pathfilters

### DIFF
--- a/ApiSurface/version.json
+++ b/ApiSurface/version.json
@@ -3,5 +3,16 @@
   "publicReleaseRefSpec": [
     "^refs/heads/main$"
   ],
-  "pathFilters": null
+  "pathFilters": [
+    ":/",
+    ":^ApiSurface/Test/",
+    ":^.github/",
+    ":^.config/",
+    ":^hooks/",
+    ":^analyzers/",
+    ":^.editorconfig",
+    ":^CONTRIBUTING.md",
+    ":^.git-blame-ignore-revs",
+    ":^.gitignore"
+  ]
 }


### PR DESCRIPTION
We've got a bunch of churn in our publishes, which we don't need. This is basically a copy of [the same file in HeterogeneousCollections](https://github.com/G-Research/HeterogeneousCollections/blob/236cb414e8ed4aa98eff234fb4e702c5af39bc4a/HeterogeneousCollections/version.json). See [the spec](https://github.com/dotnet/Nerdbank.GitVersioning/blob/bf4fa8afadae8a2ab26051736e358fd952831220/doc/pathFilters.md).