### PR TITLE
Bump .NET tools

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "fantomas": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "commands": [
         "fantomas"
       ]
     },
     "fsharp-analyzers": {
-      "version": "0.30.0",
+      "version": "0.31.0",
       "commands": [
         "fsharp-analyzers"
       ]

--- a/analyzers/analyzers.fsproj
+++ b/analyzers/analyzers.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.14.0]" />
+    <PackageDownload Include="G-Research.FSharp.Analyzers" Version="[0.15.0]" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is the non-user-visible part of https://github.com/G-Research/ApiSurface/pull/112, patched up to bring the analysers in sync with the tool upgrade.