### PR TITLE
ci: bump common-actions to node24-capable SHA

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -129,7 +129,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: G-Research/common-actions/check-required-lite@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b # main
+      - uses: G-Research/common-actions/check-required-lite@901acf923ac37b7f61777c210cb5145c2d9f489a # main
         with:
           needs-context: ${{ toJSON(needs) }}
 
@@ -162,7 +162,7 @@ jobs:
         with:
             user: ${{ secrets.NUGET_USER }}
       - name: Publish NuGet package
-        uses: G-Research/common-actions/publish-nuget@19d7281a0f9f83e13c78f99a610dbc80fc59ba3b # main
+        uses: G-Research/common-actions/publish-nuget@901acf923ac37b7f61777c210cb5145c2d9f489a # main
         with:
           package-name: ApiSurface
           nuget-key: ${{ steps.login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
follow-up to the sha-pinning campaign. our refs to `G-Research/common-actions/{check-required-lite,publish-nuget}` were locked at `19d7281a` (still node20 internally). github forces node24 on `runs.using: node20` actions starting 2026-06-02, so this bumps the pin to `901acf92` (common-actions#11), which is the first commit on `main` where these reusable actions declare `node24`.

no behavioral change; only the SHA moves forward. trailing `# main` comment preserved.